### PR TITLE
Fix broken output on "linux terminals".

### DIFF
--- a/TheRuleOfSilvester/Program.cs
+++ b/TheRuleOfSilvester/Program.cs
@@ -27,7 +27,7 @@ namespace TheRuleOfSilvester
             {
                 Console.Clear();
                 //are = new AutoResetEvent(false);
-                Console.OutputEncoding = Encoding.Unicode;
+                Console.OutputEncoding = Encoding.UTF8;
                 Console.CursorVisible = false;
                 inputComponent = new InputComponent();
                 multiplayerComponent = new MultiplayerComponent();


### PR DESCRIPTION
Change output encoding from Unicode(UTF16) to UTF8 to fix broken output on utf8-terminals. (tested on urxvt and xterm)
Should be tested on windows.