### PR TITLE
Made it work on linux

### DIFF
--- a/TheRuleOfSilvester.Core/TheRuleOfSilvester.Core.csproj
+++ b/TheRuleOfSilvester.Core/TheRuleOfSilvester.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <Version>0.1.0</Version>
   </PropertyGroup>

--- a/TheRuleOfSilvester.Core/TheRuleOfSilvester.Core.csproj
+++ b/TheRuleOfSilvester.Core/TheRuleOfSilvester.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <Version>0.1.0</Version>
   </PropertyGroup>

--- a/TheRuleOfSilvester.Network/TheRuleOfSilvester.Network.csproj
+++ b/TheRuleOfSilvester.Network/TheRuleOfSilvester.Network.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Version>0.1.0</Version>
   </PropertyGroup>
 

--- a/TheRuleOfSilvester.Network/TheRuleOfSilvester.Network.csproj
+++ b/TheRuleOfSilvester.Network/TheRuleOfSilvester.Network.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <Version>0.1.0</Version>
   </PropertyGroup>
 

--- a/TheRuleOfSilvester.Server/TheRuleOfSilvester.Server.csproj
+++ b/TheRuleOfSilvester.Server/TheRuleOfSilvester.Server.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
     <LangVersion>7.2</LangVersion>
     <Version>0.1.0</Version>
   </PropertyGroup>

--- a/TheRuleOfSilvester.Server/TheRuleOfSilvester.Server.csproj
+++ b/TheRuleOfSilvester.Server/TheRuleOfSilvester.Server.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <LangVersion>7.2</LangVersion>
     <Version>0.1.0</Version>
   </PropertyGroup>

--- a/TheRuleOfSilvester/TheRuleOfSilvester.csproj
+++ b/TheRuleOfSilvester/TheRuleOfSilvester.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
     <FileVersion>1.1.0.0</FileVersion>

--- a/TheRuleOfSilvester/TheRuleOfSilvester.csproj
+++ b/TheRuleOfSilvester/TheRuleOfSilvester.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
     <FileVersion>1.1.0.0</FileVersion>


### PR DESCRIPTION
Add netcoreapp3.1 as target-framework to make it running on (at least my) linux.
Maybe it need some changes, because I can't figure out what "netstandard"s core-equivalent should be.
Couldn't test it on windows, too.

Nevertheless its now running on my machine using: 
`dotnet run -f netcoreapp3.1 --project TheRuleOfSilvester`